### PR TITLE
chore(release): v2026.4.23-tangbao.1 release notes

### DIFF
--- a/RELEASE_v2026.4.23-tangbao.1.md
+++ b/RELEASE_v2026.4.23-tangbao.1.md
@@ -1,0 +1,23 @@
+# Hermes Agent v2026.4.23-tangbao.1
+
+**Base Version:** v0.11.0 (Official)
+**Release Date:** April 24, 2026
+
+> 本版本是基于官方 **v0.11.0** 的深度定制版（脏脏包系列），在继承官方全新 TUI 和 GPT-5.5 支持的基础上，解决了内网环境下的访问受限问题以及 Gemini 模型的工具调用兼容性问题。
+
+---
+
+## ✨ 二开功能亮点
+
+- **内网访问自由 (Intranet IP Whitelisting)** — 引入 `safe_intranet_ips` 配置项，允许自定义内网 IP 段/CIDR。该功能可绕过 SSRF 保护，使 Agent 能够直接与私有网络中的本地 API 或服务进行交互。
+- **Gemini 工具调用修复 (Gemini Tool Schema Fix)** — 解决了 Gemini 模型在处理包含 `integer enum` 类型的工具参数时发生的架构不匹配错误。通过自动类型转换，确保了 Gemini 在 Discord 等工具场景下的正常运作。
+
+---
+
+## 👥 贡献者
+
+- **@DongWei-4** — 脏脏包系列主要开发者
+
+---
+
+**Full Changelog**: [v2026.4.16-tangbao.1...v2026.4.23-tangbao.1](https://github.com/DongWei-4/hermes-agent/compare/v2026.4.16-tangbao.1...v2026.4.23-tangbao.1)


### PR DESCRIPTION
## What does this PR do?

Adds release notes for the tangbao.1 edition of v2026.4.23 (Base: v0.11.0).

## Related Issue

N/A

## Type of Change

- [x] 📝 Documentation update

## Changes Made

- Added `RELEASE_v2026.4.23-tangbao.1.md` with release highlights for the "dirty-bun" / "tangbao" edition.

## How to Test

1. Check the content of `RELEASE_v2026.4.23-tangbao.1.md`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
