### PR TITLE
fix: normalize empty tool-call content for affected chat APIs

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -6891,6 +6891,48 @@ class AIAgent:
                     content[-1]["cache_control"] = {"type": "ephemeral"}
                 break
 
+    def _normalize_empty_tool_call_content_for_api(self, api_messages: list) -> list:
+        """Normalize provider-incompatible assistant tool-call content.
+
+        Some OpenAI-compatible Chat Completions endpoints reject historical
+        assistant messages that contain tool_calls with an empty-string content
+        field. Keep the persisted/internal history unchanged and only rewrite
+        the outgoing API copy for known-affected chat-completions routes.
+        """
+        if self.api_mode != "chat_completions":
+            return api_messages
+
+        provider = str(getattr(self, "provider", "") or "").lower()
+        base_url = str(getattr(self, "base_url", "") or "")
+        is_affected_route = (
+            provider == "custom:jingua-fengxinzi"
+            or base_url.rstrip("/") == "https://gua.guagua.uk/v1"
+            or base_url_host_matches(base_url, "generativelanguage.googleapis.com")
+        )
+        if not is_affected_route:
+            return api_messages
+
+        needs_copy = any(
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and msg.get("tool_calls")
+            and msg.get("content") == ""
+            for msg in api_messages
+        )
+        if not needs_copy:
+            return api_messages
+
+        normalized = copy.deepcopy(api_messages)
+        for msg in normalized:
+            if (
+                isinstance(msg, dict)
+                and msg.get("role") == "assistant"
+                and msg.get("tool_calls")
+                and msg.get("content") == ""
+            ):
+                msg["content"] = None
+        return normalized
+
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
         if self.api_mode == "anthropic_messages":
@@ -6958,6 +7000,7 @@ class AIAgent:
             )
 
         # ── chat_completions (default) ─────────────────────────────────────
+        api_messages = self._normalize_empty_tool_call_content_for_api(api_messages)
         _ct = self._get_transport()
 
         # Provider detection flags

--- a/tests/run_agent/test_empty_tool_call_content_normalization.py
+++ b/tests/run_agent/test_empty_tool_call_content_normalization.py
@@ -1,0 +1,119 @@
+def _agent(provider="custom", base_url="https://gua.guagua.uk/v1", api_mode="chat_completions"):
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = provider
+    agent.base_url = base_url
+    agent.api_mode = api_mode
+    agent.model = "test-model"
+    agent.tools = []
+    agent.max_tokens = 128
+    agent.reasoning_config = None
+    agent.request_overrides = {}
+    agent.session_id = "test-session"
+    agent.providers_allowed = []
+    agent.providers_ignored = []
+    agent.providers_order = []
+    agent.provider_sort = None
+    agent.provider_require_parameters = False
+    agent.provider_data_collection = None
+    agent._base_url_lower = base_url.lower()
+    agent._base_url_hostname = ""
+    agent._ollama_num_ctx = None
+    agent._ephemeral_max_output_tokens = None
+    agent._resolved_api_call_timeout = lambda: 30
+    return agent
+
+
+def _messages():
+    return [
+        {"role": "user", "content": "inspect something"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_probe",
+                    "type": "function",
+                    "function": {"name": "noop_probe", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_probe", "content": "{}"},
+    ]
+
+
+def test_jingua_chat_completion_empty_tool_call_content_is_null_in_api_copy_only():
+    agent = _agent(provider="custom", base_url="https://gua.guagua.uk/v1")
+    original = _messages()
+
+    normalized = agent._normalize_empty_tool_call_content_for_api(original)
+
+    assert normalized[1]["content"] is None
+    assert original[1]["content"] == ""
+    assert normalized[1] is not original[1]
+    assert normalized[1]["tool_calls"] is not original[1]["tool_calls"]
+
+
+def test_google_chat_completion_empty_tool_call_content_is_null_in_api_copy_only():
+    agent = _agent(
+        provider="gemini",
+        base_url="https://generativelanguage.googleapis.com/v1beta/chat/completions",
+    )
+    original = _messages()
+
+    normalized = agent._normalize_empty_tool_call_content_for_api(original)
+
+    assert normalized[1]["content"] is None
+    assert original[1]["content"] == ""
+
+
+def test_non_target_provider_preserves_empty_tool_call_content_and_object_identity():
+    agent = _agent(provider="custom", base_url="https://example.invalid/v1")
+    original = _messages()
+
+    normalized = agent._normalize_empty_tool_call_content_for_api(original)
+
+    assert normalized is original
+    assert normalized[1]["content"] == ""
+
+
+def test_non_empty_tool_call_content_is_not_modified_for_target_provider():
+    agent = _agent(provider="custom", base_url="https://gua.guagua.uk/v1")
+    original = _messages()
+    original[1]["content"] = "Tool call requested."
+
+    normalized = agent._normalize_empty_tool_call_content_for_api(original)
+
+    assert normalized is original
+    assert normalized[1]["content"] == "Tool call requested."
+
+
+def test_native_modes_do_not_apply_chat_completion_compatibility_shim():
+    agent = _agent(
+        provider="gemini",
+        base_url="https://generativelanguage.googleapis.com/v1beta/chat/completions",
+        api_mode="codex_responses",
+    )
+    original = _messages()
+
+    normalized = agent._normalize_empty_tool_call_content_for_api(original)
+
+    assert normalized is original
+    assert normalized[1]["content"] == ""
+
+
+def test_build_api_kwargs_sends_normalized_copy_to_chat_transport():
+    agent = _agent(provider="custom", base_url="https://gua.guagua.uk/v1")
+    original = _messages()
+
+    class _Transport:
+        def build_kwargs(self, **kwargs):
+            return kwargs
+
+    agent._get_transport = lambda: _Transport()
+
+    api_kwargs = agent._build_api_kwargs(original)
+
+    assert api_kwargs["messages"][1]["content"] is None
+    assert original[1]["content"] == ""


### PR DESCRIPTION
## Summary
- Normalize affected Chat Completions outgoing payloads so historical assistant tool-call messages with `content: ""` are sent as `content: null`.
- Scope the shim to known affected routes (`gua.guagua.uk`, `custom:jingua-fengxinzi`, and `generativelanguage.googleapis.com`).
- Keep persisted/session history unchanged and leave non-target providers/native modes untouched.

Fixes #5

## Test Plan
- [x] `PYTHONPATH=. /home/openclaw/dev/hermes-agent/.venv/bin/python -m pytest tests/run_agent/test_empty_tool_call_content_normalization.py tests/run_agent/test_dict_tool_call_args.py tests/agent/transports/test_chat_completions.py -q`
- Result: `48 passed`

## Notes
- Local worktree was rebased onto current `origin/master` (`e5451dac`, CI quality gate) and tests passed there.
- Pushing the rebased branch to the fork was blocked because the existing Brownie classic token lacks GitHub `workflow` scope and upstream master now contains `.github/workflows/contributor-check.yml`. The PR head therefore uses the already-pushed fork branch commit; GitHub can still merge/rebase it against `master`.
