### PR TITLE
feat(feishu): opt-in LaTeX normalization

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -264,6 +264,18 @@ FALLBACK_ATTACHMENT_TEXT = "[Attachment]"
 
 _PREFERRED_LOCALES = ("zh_cn", "en_us")
 _MARKDOWN_SPECIAL_CHARS_RE = re.compile(r"([\\`*_{}\[\]()#+\-!|>~])")
+_LATEX_DELIMITER_RE = re.compile(r"(\\\(|\\\)|\\\[|\\\]|\$\$)")
+_LATEX_COMMAND_REPLACEMENTS = {
+    "alpha": "α", "beta": "β", "gamma": "γ", "delta": "δ", "epsilon": "ε",
+    "theta": "θ", "lambda": "λ", "mu": "μ", "pi": "π", "rho": "ρ", "sigma": "σ",
+    "tau": "τ", "phi": "φ", "omega": "ω", "Gamma": "Γ", "Delta": "Δ", "Theta": "Θ",
+    "Lambda": "Λ", "Pi": "Π", "Sigma": "Σ", "Phi": "Φ", "Omega": "Ω",
+    "times": "×", "cdot": "·", "div": "÷", "pm": "±", "mp": "∓",
+    "leq": "≤", "le": "≤", "geq": "≥", "ge": "≥", "neq": "≠", "ne": "≠",
+    "approx": "≈", "sim": "∼", "equiv": "≡", "to": "→", "rightarrow": "→", "leftarrow": "←",
+    "infty": "∞", "partial": "∂", "nabla": "∇", "forall": "∀", "exists": "∃", "in": "∈",
+    "notin": "∉", "subset": "⊂", "subseteq": "⊆", "cup": "∪", "cap": "∩",
+}
 _MENTION_PLACEHOLDER_RE = re.compile(r"@_user_\d+")
 _MENTION_BOUNDARY_CHARS = frozenset(" \t\n\r.,;:!?、，。；：！？()[]{}<>\"'`")
 _TRAILING_TERMINAL_PUNCT = frozenset(" \t\n\r.!?。！？")
@@ -412,6 +424,173 @@ class FeishuBatchState:
 
 def _escape_markdown_text(text: str) -> str:
     return _MARKDOWN_SPECIAL_CHARS_RE.sub(r"\\\1", text)
+
+
+def _consume_braced_group(text: str, start: int) -> tuple[str, int] | None:
+    if start >= len(text) or text[start] != "{":
+        return None
+    depth = 0
+    body_start = start + 1
+    for index in range(start, len(text)):
+        char = text[index]
+        if char == "{":
+            depth += 1
+        elif char == "}":
+            depth -= 1
+            if depth == 0:
+                return text[body_start:index], index + 1
+    return None
+
+
+def _normalize_latex_math_segment(segment: str) -> str:
+    """Best-effort conversion of common LaTeX math into Feishu-readable text."""
+    result: List[str] = []
+    index = 0
+    while index < len(segment):
+        if segment.startswith(r"\frac", index):
+            numerator = _consume_braced_group(segment, index + len(r"\frac"))
+            if numerator:
+                denominator = _consume_braced_group(segment, numerator[1])
+                if denominator:
+                    result.append(
+                        f"({_normalize_latex_math_segment(numerator[0])})/({_normalize_latex_math_segment(denominator[0])})"
+                    )
+                    index = denominator[1]
+                    continue
+        if segment.startswith(r"\sqrt", index):
+            radicand = _consume_braced_group(segment, index + len(r"\sqrt"))
+            if radicand:
+                result.append(f"√({_normalize_latex_math_segment(radicand[0])})")
+                index = radicand[1]
+                continue
+        if segment[index] == "\\":
+            match = re.match(r"\\([A-Za-z]+)", segment[index:])
+            if match:
+                command = match.group(1)
+                result.append(_LATEX_COMMAND_REPLACEMENTS.get(command, match.group(0)))
+                index += len(match.group(0))
+                continue
+            if index + 1 < len(segment):
+                result.append(segment[index:index + 2])
+                index += 2
+                continue
+        if segment[index] in "{}":
+            index += 1
+            continue
+        result.append(segment[index])
+        index += 1
+    return "".join(result)
+
+
+def _normalize_bare_latex_commands(segment: str) -> str:
+    """Normalize LaTeX commands outside delimiters without stripping ordinary braces."""
+    result: List[str] = []
+    index = 0
+    while index < len(segment):
+        if segment.startswith(r"\frac", index):
+            numerator = _consume_braced_group(segment, index + len(r"\frac"))
+            if numerator:
+                denominator = _consume_braced_group(segment, numerator[1])
+                if denominator:
+                    result.append(
+                        f"({_normalize_latex_math_segment(numerator[0])})/({_normalize_latex_math_segment(denominator[0])})"
+                    )
+                    index = denominator[1]
+                    continue
+        if segment.startswith(r"\sqrt", index):
+            radicand = _consume_braced_group(segment, index + len(r"\sqrt"))
+            if radicand:
+                result.append(f"√({_normalize_latex_math_segment(radicand[0])})")
+                index = radicand[1]
+                continue
+        if segment[index] == "\\":
+            match = re.match(r"\\([A-Za-z]+)", segment[index:])
+            if match and match.group(1) in _LATEX_COMMAND_REPLACEMENTS:
+                result.append(_LATEX_COMMAND_REPLACEMENTS[match.group(1)])
+                index += len(match.group(0))
+                continue
+        result.append(segment[index])
+        index += 1
+    return "".join(result)
+
+
+def _strip_latex_math_delimiters(text: str) -> str:
+    return _LATEX_DELIMITER_RE.sub("", text)
+
+
+def _normalize_latex_in_plain_segment(segment: str) -> str:
+    segment = re.sub(
+        r"\\\((.*?)\\\)",
+        lambda match: _normalize_latex_math_segment(match.group(1)),
+        segment,
+        flags=re.DOTALL,
+    )
+    segment = re.sub(
+        r"\\\[(.*?)\\\]",
+        lambda match: _normalize_latex_math_segment(match.group(1)),
+        segment,
+        flags=re.DOTALL,
+    )
+    segment = re.sub(
+        r"\$\$(.*?)\$\$",
+        lambda match: _normalize_latex_math_segment(match.group(1)),
+        segment,
+        flags=re.DOTALL,
+    )
+    # Single-dollar math is ambiguous with currency. Treat it as math only when
+    # the opening `$` is not directly starting a numeric amount (e.g. `$50`) and
+    # not part of a currency suffix such as `US$199`.
+    segment = re.sub(
+        r"(?<![\\A-Za-z0-9_])\$(?![\$\d])(.+?)(?<!\\)\$",
+        lambda match: _normalize_latex_math_segment(match.group(1)),
+        segment,
+        flags=re.DOTALL,
+    )
+    # Some models emit bare LaTeX commands without explicit math delimiters.
+    segment = _normalize_bare_latex_commands(segment)
+    return _strip_latex_math_delimiters(segment)
+
+
+def _normalize_latex_for_feishu(content: str) -> str:
+    """Normalize LaTeX-ish model output while leaving fenced/inline code intact."""
+    parts: List[str] = []
+    current: List[str] = []
+    in_fence = False
+
+    def flush_plain() -> None:
+        nonlocal current
+        if current:
+            parts.append(_normalize_latex_in_plain_segment("".join(current)))
+            current = []
+
+    for line in content.splitlines(keepends=True):
+        if line.lstrip().startswith("```"):
+            if not in_fence:
+                flush_plain()
+            in_fence = not in_fence
+            parts.append(line)
+            continue
+        if in_fence:
+            parts.append(line)
+            continue
+        position = 0
+        while position < len(line):
+            match = re.search(r"`+", line[position:])
+            if not match:
+                current.append(line[position:])
+                break
+            start = position + match.start()
+            tick_run = match.group(0)
+            end = line.find(tick_run, start + len(tick_run))
+            if end == -1:
+                current.append(line[position:])
+                break
+            current.append(line[position:start])
+            flush_plain()
+            parts.append(line[start:end + len(tick_run)])
+            position = end + len(tick_run)
+    flush_plain()
+    return "".join(parts)
 
 
 def _to_boolean(value: Any) -> bool:
@@ -2035,8 +2214,8 @@ class FeishuAdapter(BasePlatformAdapter):
             return fallback
 
     def format_message(self, content: str) -> str:
-        """Feishu text messages are plain text by default."""
-        return content.strip()
+        """Normalize outbound Feishu text before choosing text vs post payload."""
+        return _normalize_latex_for_feishu(content.strip())
 
     # =========================================================================
     # Inbound event handlers

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -399,6 +399,7 @@ class FeishuAdapterSettings:
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
+    latex_normalization_enabled: bool = False
 
 
 @dataclass
@@ -1568,6 +1569,12 @@ class FeishuAdapter(BasePlatformAdapter):
 
         # Default group policy (for groups not in group_rules)
         default_group_policy = str(extra.get("default_group_policy", "")).strip().lower()
+        latex_normalization_enabled = _to_boolean(
+            extra.get(
+                "latex_normalization_enabled",
+                extra.get("latex_normalization", os.getenv("HERMES_FEISHU_LATEX_NORMALIZATION", "false")),
+            )
+        )
 
         return FeishuAdapterSettings(
             app_id=str(extra.get("app_id") or os.getenv("FEISHU_APP_ID", "")).strip(),
@@ -1625,6 +1632,7 @@ class FeishuAdapter(BasePlatformAdapter):
             admins=admins,
             default_group_policy=default_group_policy,
             group_rules=group_rules,
+            latex_normalization_enabled=latex_normalization_enabled,
         )
 
     def _apply_settings(self, settings: FeishuAdapterSettings) -> None:
@@ -1655,6 +1663,11 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_reconnect_interval = settings.ws_reconnect_interval
         self._ws_ping_interval = settings.ws_ping_interval
         self._ws_ping_timeout = settings.ws_ping_timeout
+        self._latex_normalization_enabled = settings.latex_normalization_enabled
+
+    def set_latex_normalization_enabled(self, enabled: bool) -> None:
+        """Enable or disable outbound LaTeX normalization for this Feishu adapter."""
+        self._latex_normalization_enabled = bool(enabled)
 
     def _build_event_handler(self) -> Any:
         if EventDispatcherHandler is None:
@@ -2215,7 +2228,10 @@ class FeishuAdapter(BasePlatformAdapter):
 
     def format_message(self, content: str) -> str:
         """Normalize outbound Feishu text before choosing text vs post payload."""
-        return _normalize_latex_for_feishu(content.strip())
+        stripped = content.strip()
+        if not getattr(self, "_latex_normalization_enabled", False):
+            return stripped
+        return _normalize_latex_for_feishu(stripped)
 
     # =========================================================================
     # Inbound event handlers

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3617,6 +3617,9 @@ class GatewayRunner:
         if canonical == "reasoning":
             return await self._handle_reasoning_command(event)
 
+        if canonical == "latex":
+            return await self._handle_latex_command(event)
+
         if canonical == "fast":
             return await self._handle_fast_command(event)
 
@@ -6906,6 +6909,65 @@ class GatewayRunner:
             return f"🧠 ✓ Reasoning effort set to `{effort}` (saved to config)\n_(takes effect on next message)_"
         else:
             return f"🧠 ✓ Reasoning effort set to `{effort}` (this session only)"
+
+    async def _handle_latex_command(self, event: MessageEvent) -> str:
+        """Handle /latex — toggle Feishu outbound LaTeX normalization.
+
+        Usage:
+            /latex              Show current Feishu LaTeX normalization state
+            /latex status       Show current Feishu LaTeX normalization state
+            /latex on           Enable normalization for Feishu outbound messages
+            /latex off          Disable normalization for Feishu outbound messages
+        """
+        import yaml
+
+        if event.source.platform != Platform.FEISHU:
+            return "🧮 /latex controls Feishu message rendering and is only available from Feishu chats."
+
+        args = event.get_command_args().strip().lower()
+        if args in {"", "status"}:
+            adapter = self.adapters.get(Platform.FEISHU)
+            enabled = bool(getattr(adapter, "_latex_normalization_enabled", False)) if adapter else False
+            state = "ON" if enabled else "OFF"
+            return (
+                "🧮 **Feishu LaTeX Rendering**\n\n"
+                f"Current mode: **{state}**\n\n"
+                "When ON, common LaTeX math such as `\\alpha`, `\\leq`, `\\frac{a}{b}` "
+                "is converted to Feishu-readable symbols. Default is OFF.\n\n"
+                "_Usage:_ `/latex <on|off|status>`"
+            )
+
+        if args in {"on", "enable", "enabled"}:
+            enabled = True
+            label = "ON"
+        elif args in {"off", "disable", "disabled"}:
+            enabled = False
+            label = "OFF"
+        else:
+            return f"⚠️ Unknown argument: `{args}`\n\n**Valid options:** on, off, status"
+
+        adapter = self.adapters.get(Platform.FEISHU)
+        if adapter and hasattr(adapter, "set_latex_normalization_enabled"):
+            adapter.set_latex_normalization_enabled(enabled)
+
+        config_path = _hermes_home / "config.yaml"
+        saved = False
+        try:
+            user_config = {}
+            if config_path.exists():
+                with open(config_path, encoding="utf-8") as f:
+                    user_config = yaml.safe_load(f) or {}
+            platforms_cfg = user_config.setdefault("platforms", {})
+            feishu_cfg = platforms_cfg.setdefault("feishu", {})
+            extra_cfg = feishu_cfg.setdefault("extra", {})
+            extra_cfg["latex_normalization_enabled"] = enabled
+            atomic_yaml_write(config_path, user_config)
+            saved = True
+        except Exception as exc:
+            logger.error("Failed to save Feishu latex normalization setting: %s", exc)
+
+        suffix = " (saved to config)" if saved else " (this session only)"
+        return f"🧮 ✓ Feishu LaTeX rendering: **{label}**{suffix}"
 
     async def _handle_fast_command(self, event: MessageEvent) -> str:
         """Handle /fast — mirror the CLI Priority Processing toggle in gateway chats."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -120,6 +120,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("reasoning", "Manage reasoning effort and display", "Configuration",
                args_hint="[level|show|hide]",
                subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "show", "hide", "on", "off")),
+    CommandDef("latex", "Toggle Feishu LaTeX-to-readable-symbol normalization", "Configuration",
+               gateway_only=True, args_hint="[on|off|status]", subcommands=("on", "off", "status")),
     CommandDef("fast", "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)", "Configuration",
                args_hint="[normal|fast|status]",
                subcommands=("normal", "fast", "status", "on", "off")),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -47,6 +47,7 @@ AUTHOR_MAP = {
     "jefferson@heimdallstrategy.com": "Mind-Dragon",
     "130918800+devorun@users.noreply.github.com": "devorun",
     "maks.mir@yahoo.com": "say8hi",
+    "brownie-ops@proton.me": "brownie-ops",
     # contributors (from noreply pattern)
     "david.vv@icloud.com": "davidvv",
     "wangqiang@wangqiangdeMac-mini.local": "xiaoqiang243",

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2344,6 +2344,58 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_format_message_normalizes_common_latex_math_for_feishu(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        self.assertEqual(
+            adapter.format_message(
+                r"令 \(\alpha \leq \frac{a+b}{\sqrt{x}}\)，且 $$y_i = x^2 \times 3$$。"
+            ),
+            "令 α ≤ (a+b)/(√(x))，且 y_i = x^2 × 3。",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_format_message_does_not_rewrite_latex_inside_code(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        self.assertEqual(
+            adapter.format_message(
+                "公式：\\(x \\to y\\)\n```python\nexpr = r'\\frac{a}{b}'\n```\n`\\alpha`"
+            ),
+            "公式：x → y\n```python\nexpr = r'\\frac{a}{b}'\n```\n`\\alpha`",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_format_message_preserves_currency_dollar_ranges(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        self.assertEqual(
+            adapter.format_message("价格是 $50 到 $100，套餐 B 是 US$199。"),
+            "价格是 $50 到 $100，套餐 B 是 US$199。",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_format_message_still_normalizes_single_dollar_math(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        self.assertEqual(
+            adapter.format_message(r"单行公式 $x \leq y$ 保持可读，中文紧贴$x \to y$也可读。"),
+            "单行公式 x ≤ y 保持可读，中文紧贴x → y也可读。",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_build_post_payload_keeps_full_markdown_text(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2344,11 +2344,23 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_format_message_normalizes_common_latex_math_for_feishu(self):
+    def test_format_message_leaves_latex_unchanged_by_default(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
         adapter = FeishuAdapter(PlatformConfig())
+
+        self.assertEqual(
+            adapter.format_message(r"令 \(\alpha \leq y\)。"),
+            r"令 \(\alpha \leq y\)。",
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_format_message_normalizes_common_latex_math_when_enabled(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"latex_normalization_enabled": True}))
 
         self.assertEqual(
             adapter.format_message(
@@ -2358,11 +2370,11 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_format_message_does_not_rewrite_latex_inside_code(self):
+    def test_format_message_does_not_rewrite_latex_inside_code_when_enabled(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
-        adapter = FeishuAdapter(PlatformConfig())
+        adapter = FeishuAdapter(PlatformConfig(extra={"latex_normalization_enabled": True}))
 
         self.assertEqual(
             adapter.format_message(
@@ -2372,11 +2384,11 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_format_message_preserves_currency_dollar_ranges(self):
+    def test_format_message_preserves_currency_dollar_ranges_when_enabled(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
-        adapter = FeishuAdapter(PlatformConfig())
+        adapter = FeishuAdapter(PlatformConfig(extra={"latex_normalization_enabled": True}))
 
         self.assertEqual(
             adapter.format_message("价格是 $50 到 $100，套餐 B 是 US$199。"),
@@ -2384,11 +2396,11 @@ class TestAdapterBehavior(unittest.TestCase):
         )
 
     @patch.dict(os.environ, {}, clear=True)
-    def test_format_message_still_normalizes_single_dollar_math(self):
+    def test_format_message_still_normalizes_single_dollar_math_when_enabled(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
 
-        adapter = FeishuAdapter(PlatformConfig())
+        adapter = FeishuAdapter(PlatformConfig(extra={"latex_normalization_enabled": True}))
 
         self.assertEqual(
             adapter.format_message(r"单行公式 $x \leq y$ 保持可读，中文紧贴$x \to y$也可读。"),

--- a/tests/gateway/test_latex_command.py
+++ b/tests/gateway/test_latex_command.py
@@ -1,0 +1,129 @@
+"""Tests for gateway /latex command and Feishu LaTeX normalization toggling."""
+
+import asyncio
+from types import SimpleNamespace
+
+import yaml
+
+import gateway.run as gateway_run
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent
+from gateway.session import SessionSource
+
+
+def _make_event(text="/latex", platform=Platform.FEISHU, user_id="ou_user", chat_id="oc_chat"):
+    source = SessionSource(
+        platform=platform,
+        user_id=user_id,
+        chat_id=chat_id,
+        user_name="testuser",
+    )
+    return MessageEvent(text=text, source=source)
+
+
+def _make_runner():
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {}
+    return runner
+
+
+class TestLatexCommand:
+    def test_latex_is_in_gateway_known_commands(self):
+        from hermes_cli.commands import GATEWAY_KNOWN_COMMANDS
+
+        assert "latex" in GATEWAY_KNOWN_COMMANDS
+
+    def test_feishu_adapter_default_keeps_latex_unchanged(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+
+        assert adapter.format_message(r"公式 \(\alpha \leq y\)") == r"公式 \(\alpha \leq y\)"
+
+    def test_feishu_adapter_config_can_enable_latex_normalization(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"latex_normalization_enabled": True}))
+
+        assert adapter.format_message(r"公式 \(\alpha \leq y\)") == "公式 α ≤ y"
+
+    def test_feishu_adapter_legacy_config_name_can_enable_latex_normalization(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig(extra={"latex_normalization": True}))
+
+        assert adapter.format_message(r"公式 \(x \to y\)") == "公式 x → y"
+
+    def test_feishu_adapter_live_toggle_updates_formatting(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        assert adapter.format_message(r"公式 \(x \to y\)") == r"公式 \(x \to y\)"
+
+        adapter.set_latex_normalization_enabled(True)
+        assert adapter.format_message(r"公式 \(x \to y\)") == "公式 x → y"
+
+    async def _run_latex_command(self, tmp_path, monkeypatch, command):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        config_path = hermes_home / "config.yaml"
+        config_path.write_text(
+            "platforms:\n"
+            "  feishu:\n"
+            "    enabled: true\n"
+            "    extra:\n"
+            "      app_id: cli_xxx\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        adapter = SimpleNamespace(_latex_normalization_enabled=False)
+        adapter.set_latex_normalization_enabled = lambda value: setattr(
+            adapter, "_latex_normalization_enabled", bool(value)
+        )
+        runner.adapters = {Platform.FEISHU: adapter}
+
+        result = await runner._handle_latex_command(_make_event(command))
+        saved = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+        return result, saved, adapter
+
+    def test_latex_on_persists_feishu_extra_and_updates_adapter(self, tmp_path, monkeypatch):
+        result, saved, adapter = asyncio.run(
+            self._run_latex_command(tmp_path, monkeypatch, "/latex on")
+        )
+
+        assert "ON" in result
+        assert adapter._latex_normalization_enabled is True
+        assert saved["platforms"]["feishu"]["extra"]["latex_normalization_enabled"] is True
+
+    def test_latex_off_persists_feishu_extra_and_updates_adapter(self, tmp_path, monkeypatch):
+        result, saved, adapter = asyncio.run(
+            self._run_latex_command(tmp_path, monkeypatch, "/latex off")
+        )
+
+        assert "OFF" in result
+        assert adapter._latex_normalization_enabled is False
+        assert saved["platforms"]["feishu"]["extra"]["latex_normalization_enabled"] is False
+
+    def test_latex_status_reports_current_adapter_state(self, tmp_path, monkeypatch):
+        result, _saved, adapter = asyncio.run(
+            self._run_latex_command(tmp_path, monkeypatch, "/latex status")
+        )
+
+        assert "OFF" in result
+        assert adapter._latex_normalization_enabled is False
+
+    def test_latex_rejects_non_feishu_platform(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        hermes_home.mkdir()
+        monkeypatch.setattr(gateway_run, "_hermes_home", hermes_home)
+
+        runner = _make_runner()
+        result = asyncio.run(runner._handle_latex_command(_make_event("/latex on", platform=Platform.TELEGRAM)))
+
+        assert "Feishu" in result


### PR DESCRIPTION
## Summary
- Normalize common LaTeX math delimiters and commands in Feishu outbound messages, but keep it **disabled by default**
- Add Feishu config/env toggle: `platforms.feishu.extra.latex_normalization_enabled` (legacy alias `latex_normalization`, env fallback `HERMES_FEISHU_LATEX_NORMALIZATION`)
- Add gateway-only `/latex` command in Feishu chats: `/latex status`, `/latex on`, `/latex off`; on/off updates the live adapter and persists to `config.yaml`
- Preserve fenced code/inline code and currency-looking dollar ranges during normalization

## Feasibility
Feasible at the Feishu adapter layer because outbound Feishu text passes through `FeishuAdapter.format_message()` before the adapter chooses Feishu text vs post payloads. The model/provider output is unchanged, and the feature is opt-in so normal Feishu rendering remains identical unless enabled by config or `/latex on`.

## Test Plan
- `.venv/bin/python -m pytest tests/gateway/test_feishu.py tests/gateway/test_latex_command.py -q -o 'addopts='`
- `.venv/bin/python -m py_compile gateway/platforms/feishu.py gateway/run.py hermes_cli/commands.py tests/gateway/test_feishu.py tests/gateway/test_latex_command.py`

Note: This PR branch was created from `brownie/master` and pushed from the Brownie fork.
