### PR TITLE
chore(tangbao): replay retained patches on v2026.5.7

### DIFF
--- a/docs/tangbao/fork-management.md
+++ b/docs/tangbao/fork-management.md
@@ -1,0 +1,141 @@
+# Tangbao Custom Fork Management
+
+This document defines how developer agents maintain the Tangbao custom release line while following upstream Hermes Agent and preserving household-specific patches. It is intentionally strict: internal PRs that violate these rules should be blocked until corrected.
+
+## Audience and Roles
+
+This document is written for Brownie and other developer/reviewer agents working in the repository, not for Tangbao as an implementation actor.
+
+- **Tangbao** is the owner/requester and the household custom-distribution context.
+- **Brownie or another developer agent** prepares branches, patch records, tests, reports, and PRs.
+- **Dirty-bun or an explicitly authorized operator** owns production release, rollback, service restart, and tag publication.
+
+## Goals
+
+- Keep the household production environment safe and reproducible.
+- Minimize long-lived divergence from upstream.
+- Make every Tangbao custom behavior auditable, testable, and droppable when upstream supersedes it.
+- Separate upstream synchronization, custom patch maintenance, release notes, and production deployment.
+
+## Repository Model
+
+Treat the fork as:
+
+```text
+official upstream tag/main
+  -> household integration branch for a Tangbao custom release
+  -> small developer-agent feature/fix branches
+  -> Tangbao custom release tag
+```
+
+Do not treat the fork as an unstructured permanent divergence or as documentation addressed to Tangbao as the implementer.
+
+### Branch Layers
+
+| Layer | Example | Purpose | Rules |
+|---|---|---|---|
+| Upstream baseline | `upstream-v2026.4.30` / upstream tag | Exact official source | Never edit. Only fetch/verify. |
+| Upgrade integration | `upgrade/v2026.4.30-tangbao.1` | Replay selected household patches onto a new upstream base | May contain retained custom patches and upgrade docs only. |
+| Feature/fix branch | `fix/custom-provider-key-precedence` | One logical custom change prepared by a developer agent | Small, reviewed, tested, and independently droppable. |
+| Release prep | `release/v2026.4.30-tangbao.1-prep` | Release notes and planned tag instructions | No functional code changes unless explicitly approved. |
+| Production | `/home/openclaw/hermes-prod/current` | Live household runtime | Read-only to Brownie unless explicitly authorized. |
+
+## Patch Queue Discipline
+
+Every household-specific Tangbao custom behavior must have a patch record. The record should answer:
+
+- What problem does this solve?
+- Which commit(s) implement it?
+- Which tests prove it?
+- Has upstream fixed it?
+- What is the drop condition?
+- Is this household-specific or suitable for upstream PR?
+
+Use this status taxonomy during every upstream upgrade:
+
+| Status | Meaning | Required action |
+|---|---|---|
+| `keep` | Upstream has not fixed it | Replay/adapt patch and run tests. |
+| `drop` | Upstream fully supersedes it | Remove from patch queue and document why. |
+| `adapt` | Upstream partly overlaps or changed nearby code | Rewrite patch minimally on new base. |
+| `upstream-pr` | Should be contributed upstream | Keep locally until upstream merges; then reassess as `drop`. |
+| `hold` | Risk or unclear behavior | Do not ship production release until resolved. |
+
+## Upgrade Workflow
+
+For a new official release, use a fresh integration branch/worktree:
+
+```bash
+git fetch --prune --tags upstream
+git worktree add ~/workspaces/brownie/upgrade-vYYYY.M.D-tangbao.N \
+  -b upgrade/vYYYY.M.D-tangbao.N upstream-vYYYY.M.D
+```
+
+Then:
+
+1. Verify the official tag and release notes.
+2. Create/update the Tangbao patch record.
+3. Replay only retained custom patches, preferably one commit per logical patch.
+4. Resolve conflicts in favor of upstream unless the Tangbao patch explicitly requires otherwise.
+5. Run targeted tests for every retained patch.
+6. Run smoke tests for provider routing, gateway, tool schemas, URL safety, and release scripts when touched.
+7. Produce an upgrade report before release prep.
+8. Prepare release notes in a separate release-prep commit/PR.
+9. Do not update production or publish tags from Brownie without explicit authorization.
+
+## Review Gate for Internal PRs
+
+Brownie should reject internal PRs directly when any of these are true:
+
+- The PR modifies production checkout paths or assumes production is writable.
+- Functional changes are mixed with release-note-only changes without a clear reason.
+- A Tangbao patch lacks tests or a documented verification path.
+- A patch duplicates upstream behavior without explaining why it is still needed.
+- A change broadens SSRF/private-network access without explicit allowlist semantics and tests.
+- Secrets, tokens, or profile-private data are committed or printed in logs.
+- The PR has unresolved merge conflicts with the current upstream target.
+- The PR changes broad/core files without a small-scope rationale and targeted tests.
+- The PR is not independently droppable or mixes unrelated concerns.
+
+Approval requires:
+
+- Clear problem statement.
+- Minimal diff.
+- Relevant tests or a documented reason tests are not possible.
+- Compatibility note against the current upstream base.
+- Rollback/drop condition for Tangbao-specific behavior.
+
+## Release and Versioning Rules
+
+Tangbao custom tags use:
+
+```text
+v<official-base-date>-tangbao.<sequence>
+```
+
+The date is the official upstream base date, not the day the release is prepared. Example: the first Tangbao custom release based on official `v2026.4.30` is:
+
+```text
+v2026.4.30-tangbao.1
+```
+
+Use the wording **Tangbao custom release** / **糖包定制版**. Do not describe this release line as a Dirty-bun series.
+
+## Current v2026.5.7 Patch Assessment
+
+As of the official `v2026.5.7 / v0.13.0` assessment:
+
+| Patch | Status | Notes |
+|---|---|---|
+| Discord tool schema Gemini compatibility | `keep` | Still retained for Gemini-compatible Discord tool schema generation. |
+| Empty assistant tool-call content normalization | `keep` | Still retained for chat APIs that reject assistant tool-call messages with empty content. |
+| Tangbao fork-management documentation | `keep` | Household fork/release workflow remains local policy and should stay documented. |
+| `network.safe_intranet_ips` SSRF allowlist | `drop` | Use upstream `security.allow_private_urls: true` instead. |
+| Named custom provider credential precedence | `drop` | Fixed upstream by `e38ea3807`. |
+| Feishu opt-in LaTeX normalization | `drop` | No longer needed for this baseline. |
+| Old `v2026.4.23-tangbao.*` release metadata | `drop` | Do not mix old release metadata into the new baseline. |
+| PR quality gate workflow | `drop` | Excluded from this replay to avoid workflow-scope and PR noise. |
+
+## Production Boundary
+
+Brownie may prepare branches, tests, reports, and PRs. Production release, rollback, service restart, or tag publication belongs to Dirty-bun or requires explicit user authorization.

--- a/run_agent.py
+++ b/run_agent.py
@@ -8620,6 +8620,48 @@ class AIAgent:
                     content[-1]["cache_control"] = {"type": "ephemeral"}
                 break
 
+    def _normalize_empty_tool_call_content_for_api(self, api_messages: list) -> list:
+        """Normalize provider-incompatible assistant tool-call content.
+
+        Some OpenAI-compatible Chat Completions endpoints reject historical
+        assistant messages that contain tool_calls with an empty-string content
+        field. Keep the persisted/internal history unchanged and only rewrite
+        the outgoing API copy for known-affected chat-completions routes.
+        """
+        if self.api_mode != "chat_completions":
+            return api_messages
+
+        provider = str(getattr(self, "provider", "") or "").lower()
+        base_url = str(getattr(self, "base_url", "") or "")
+        is_affected_route = (
+            provider == "custom:jingua-fengxinzi"
+            or base_url.rstrip("/") == "https://gua.guagua.uk/v1"
+            or base_url_host_matches(base_url, "generativelanguage.googleapis.com")
+        )
+        if not is_affected_route:
+            return api_messages
+
+        needs_copy = any(
+            isinstance(msg, dict)
+            and msg.get("role") == "assistant"
+            and msg.get("tool_calls")
+            and msg.get("content") == ""
+            for msg in api_messages
+        )
+        if not needs_copy:
+            return api_messages
+
+        normalized = copy.deepcopy(api_messages)
+        for msg in normalized:
+            if (
+                isinstance(msg, dict)
+                and msg.get("role") == "assistant"
+                and msg.get("tool_calls")
+                and msg.get("content") == ""
+            ):
+                msg["content"] = None
+        return normalized
+
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
         if self.api_mode == "anthropic_messages":
@@ -8689,6 +8731,7 @@ class AIAgent:
             )
 
         # ── chat_completions (default) ─────────────────────────────────────
+        api_messages = self._normalize_empty_tool_call_content_for_api(api_messages)
         _ct = self._get_transport()
 
         # Provider detection flags

--- a/tests/run_agent/test_empty_tool_call_content_normalization.py
+++ b/tests/run_agent/test_empty_tool_call_content_normalization.py
@@ -1,0 +1,119 @@
+def _agent(provider="custom", base_url="https://gua.guagua.uk/v1", api_mode="chat_completions"):
+    from run_agent import AIAgent
+
+    agent = AIAgent.__new__(AIAgent)
+    agent.provider = provider
+    agent.base_url = base_url
+    agent.api_mode = api_mode
+    agent.model = "test-model"
+    agent.tools = []
+    agent.max_tokens = 128
+    agent.reasoning_config = None
+    agent.request_overrides = {}
+    agent.session_id = "test-session"
+    agent.providers_allowed = []
+    agent.providers_ignored = []
+    agent.providers_order = []
+    agent.provider_sort = None
+    agent.provider_require_parameters = False
+    agent.provider_data_collection = None
+    agent._base_url_lower = base_url.lower()
+    agent._base_url_hostname = ""
+    agent._ollama_num_ctx = None
+    agent._ephemeral_max_output_tokens = None
+    agent._resolved_api_call_timeout = lambda: 30
+    return agent
+
+
+def _messages():
+    return [
+        {"role": "user", "content": "inspect something"},
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                {
+                    "id": "call_probe",
+                    "type": "function",
+                    "function": {"name": "noop_probe", "arguments": "{}"},
+                }
+            ],
+        },
+        {"role": "tool", "tool_call_id": "call_probe", "content": "{}"},
+    ]
+
+
+def test_jingua_chat_completion_empty_tool_call_content_is_null_in_api_copy_only():
+    agent = _agent(provider="custom", base_url="https://gua.guagua.uk/v1")
+    original = _messages()
+
+    normalized = agent._normalize_empty_tool_call_content_for_api(original)
+
+    assert normalized[1]["content"] is None
+    assert original[1]["content"] == ""
+    assert normalized[1] is not original[1]
+    assert normalized[1]["tool_calls"] is not original[1]["tool_calls"]
+
+
+def test_google_chat_completion_empty_tool_call_content_is_null_in_api_copy_only():
+    agent = _agent(
+        provider="gemini",
+        base_url="https://generativelanguage.googleapis.com/v1beta/chat/completions",
+    )
+    original = _messages()
+
+    normalized = agent._normalize_empty_tool_call_content_for_api(original)
+
+    assert normalized[1]["content"] is None
+    assert original[1]["content"] == ""
+
+
+def test_non_target_provider_preserves_empty_tool_call_content_and_object_identity():
+    agent = _agent(provider="custom", base_url="https://example.invalid/v1")
+    original = _messages()
+
+    normalized = agent._normalize_empty_tool_call_content_for_api(original)
+
+    assert normalized is original
+    assert normalized[1]["content"] == ""
+
+
+def test_non_empty_tool_call_content_is_not_modified_for_target_provider():
+    agent = _agent(provider="custom", base_url="https://gua.guagua.uk/v1")
+    original = _messages()
+    original[1]["content"] = "Tool call requested."
+
+    normalized = agent._normalize_empty_tool_call_content_for_api(original)
+
+    assert normalized is original
+    assert normalized[1]["content"] == "Tool call requested."
+
+
+def test_native_modes_do_not_apply_chat_completion_compatibility_shim():
+    agent = _agent(
+        provider="gemini",
+        base_url="https://generativelanguage.googleapis.com/v1beta/chat/completions",
+        api_mode="codex_responses",
+    )
+    original = _messages()
+
+    normalized = agent._normalize_empty_tool_call_content_for_api(original)
+
+    assert normalized is original
+    assert normalized[1]["content"] == ""
+
+
+def test_build_api_kwargs_sends_normalized_copy_to_chat_transport():
+    agent = _agent(provider="custom", base_url="https://gua.guagua.uk/v1")
+    original = _messages()
+
+    class _Transport:
+        def build_kwargs(self, **kwargs):
+            return kwargs
+
+    agent._get_transport = lambda: _Transport()
+
+    api_kwargs = agent._build_api_kwargs(original)
+
+    assert api_kwargs["messages"][1]["content"] is None
+    assert original[1]["content"] == ""

--- a/tests/tools/test_discord_tool.py
+++ b/tests/tools/test_discord_tool.py
@@ -581,7 +581,7 @@ class TestRegistration:
         props = entry.schema["parameters"]["properties"]
         assert props["limit"]["minimum"] == 1
         assert props["limit"]["maximum"] == 100
-        assert props["auto_archive_duration"]["enum"] == [60, 1440, 4320, 10080]
+        assert props["auto_archive_duration"]["enum"] == ["60", "1440", "4320", "10080"]
 
     def test_core_schema_description(self):
         """Core schema description should mention core actions."""

--- a/tools/discord_tool.py
+++ b/tools/discord_tool.py
@@ -436,14 +436,14 @@ def _create_thread(
         path = f"/channels/{channel_id}/messages/{message_id}/threads"
         body: Dict[str, Any] = {
             "name": name,
-            "auto_archive_duration": auto_archive_duration,
+            "auto_archive_duration": int(auto_archive_duration),
         }
     else:
         # Create a standalone thread
         path = f"/channels/{channel_id}/threads"
         body = {
             "name": name,
-            "auto_archive_duration": auto_archive_duration,
+            "auto_archive_duration": int(auto_archive_duration),
             "type": 11,  # PUBLIC_THREAD
         }
     thread = _discord_request("POST", path, token, body=body)
@@ -708,9 +708,9 @@ def _build_schema(
             "description": "Snowflake ID for forward pagination (fetch_messages).",
         },
         "auto_archive_duration": {
-            "type": "integer",
-            "enum": [60, 1440, 4320, 10080],
-            "description": "Thread archive duration in minutes (create_thread, default 1440).",
+            "type": "string",
+            "description": "Duration before the channel is automatically archived (minutes).",
+            "enum": ["60", "1440", "4320", "10080"],
         },
     }
 


### PR DESCRIPTION
## Summary

Replay only the retained Tangbao/Hermes household patches on top of the pure official `v2026.5.7` baseline branch `master-v2026.5.7`.

Retained:
- Discord Gemini tool schema compatibility fix
- Empty assistant tool-call content normalization
- Tangbao fork-management documentation, updated for the v2026.5.7 keep/drop decision

Dropped from this replay:
- `safe_intranet_ips` (use upstream `security.allow_private_urls: true`)
- named custom provider credential bug (fixed upstream by `e38ea3807`)
- Feishu LaTeX normalization
- old `v2026.4.23-tangbao.*` release metadata
- PR quality gate workflow

## Verification

```bash
.venv/bin/python -m pytest \
  tests/tools/test_discord_tool.py \
  tests/run_agent/test_empty_tool_call_content_normalization.py -q
```

Result: `96 passed in 5.69s`.

## Diff scope

Expected changed files only:
- `docs/tangbao/fork-management.md`
- `run_agent.py`
- `tests/run_agent/test_empty_tool_call_content_normalization.py`
- `tests/tools/test_discord_tool.py`
- `tools/discord_tool.py`
