### PR TITLE
ci: scope PR tests to changed areas

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,28 +6,214 @@ on:
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      # Workflow-only PRs do not need to run the full source test suite.
+      # Workflow-only PRs are covered by lint/supply-chain workflows.
       - '.github/workflows/**'
   pull_request:
     branches: [master, "master-v*"]
     paths-ignore:
       - '**/*.md'
       - 'docs/**'
-      # Workflow-only PRs do not need to run the full source test suite.
+      # Workflow-only PRs are covered by lint/supply-chain workflows.
       - '.github/workflows/**'
+  workflow_dispatch:
+    inputs:
+      run_full_suite:
+        description: 'Run full non-integration pytest baseline instead of only diff-scoped tests'
+        required: false
+        default: false
+        type: boolean
+  schedule:
+    # Track baseline debt without blocking ordinary PRs.
+    - cron: '23 21 * * *'
 
 permissions:
   contents: read
 
-# Cancel in-progress runs for the same PR/branch
+# Cancel in-progress runs for the same PR/branch.
 concurrency:
   group: tests-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
-  test:
+  diff-tests:
+    name: diff-scoped tests
+    if: github.event_name != 'schedule' && github.event.inputs.run_full_suite != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
+
+      - name: Set up Python 3.11
+        run: uv python install 3.11
+
+      - name: Install dependencies
+        run: |
+          uv venv .venv --python 3.11
+          source .venv/bin/activate
+          uv pip install -e ".[all,dev]"
+
+      - name: Determine changed files and matching tests
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1 || true
+            BASE="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
+          else
+            BASE="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
+          fi
+
+          git diff --name-only --diff-filter=ACMR "$BASE"..HEAD > /tmp/changed-files.txt
+          echo "Changed files:"
+          sed 's/^/  /' /tmp/changed-files.txt
+
+          python3 - <<'PY'
+          from pathlib import Path
+
+          changed = [line.strip() for line in Path('/tmp/changed-files.txt').read_text().splitlines() if line.strip()]
+          all_tests = {str(p) for p in Path('tests').rglob('test_*.py')}
+          candidates: set[str] = set()
+          compile_files: list[str] = []
+          e2e_needed = False
+
+          def add_if_exists(path: str) -> None:
+              if path in all_tests:
+                  candidates.add(path)
+
+          for f in changed:
+              p = Path(f)
+              if p.suffix == '.py' and not f.startswith('tests/'):
+                  compile_files.append(f)
+
+              if f.startswith('tests/e2e/'):
+                  e2e_needed = True
+                  candidates.add(f)
+                  continue
+
+              if f.startswith('tests/') and p.name.startswith('test_') and p.suffix == '.py':
+                  candidates.add(f)
+                  continue
+
+              if p.suffix != '.py':
+                  continue
+
+              stem = p.stem
+              parent = p.parent.name
+
+              # High-signal direct mappings first.  This keeps a Feishu-only
+              # change on tests/gateway/test_feishu.py instead of running the
+              # entire currently-red gateway suite.
+              add_if_exists(f'tests/test_{stem}.py')
+              add_if_exists(f'tests/{parent}/test_{stem}.py')
+              if len(p.parts) >= 2:
+                  add_if_exists(f'tests/{p.parts[0]}/test_{stem}.py')
+              if len(p.parts) >= 3:
+                  add_if_exists(f'tests/{p.parts[0]}/test_{p.parts[-2]}.py')
+
+              # Common Hermes source layouts.
+              if f.startswith('gateway/platforms/'):
+                  add_if_exists(f'tests/gateway/test_{stem}.py')
+                  add_if_exists(f'tests/gateway/test_{parent}.py')
+              elif f.startswith('tools/'):
+                  add_if_exists(f'tests/tools/test_{stem}.py')
+              elif f.startswith('agent/'):
+                  add_if_exists(f'tests/agent/test_{stem}.py')
+              elif f.startswith('cron/'):
+                  add_if_exists(f'tests/cron/test_{stem}.py')
+              elif f.startswith('hermes_cli/'):
+                  add_if_exists(f'tests/hermes_cli/test_{stem}.py')
+              elif f == 'run_agent.py':
+                  for t in all_tests:
+                      if t.startswith('tests/run_agent/test_'):
+                          candidates.add(t)
+              elif f == 'model_tools.py':
+                  for t in all_tests:
+                      if 'model_tools' in Path(t).name:
+                          candidates.add(t)
+
+          Path('/tmp/pytest-targets.txt').write_text('\n'.join(sorted(candidates)) + ('\n' if candidates else ''))
+          Path('/tmp/compile-files.txt').write_text('\n'.join(compile_files) + ('\n' if compile_files else ''))
+          Path('/tmp/e2e-needed.txt').write_text('true\n' if e2e_needed else 'false\n')
+          print('Matched pytest targets:')
+          print(Path('/tmp/pytest-targets.txt').read_text() or '  <none>')
+          print('Python files to compile:')
+          print(Path('/tmp/compile-files.txt').read_text() or '  <none>')
+          print('E2E needed:', e2e_needed)
+          PY
+
+          {
+            echo 'pytest_targets<<EOF'
+            cat /tmp/pytest-targets.txt
+            echo 'EOF'
+            echo 'compile_files<<EOF'
+            cat /tmp/compile-files.txt
+            echo 'EOF'
+            echo "e2e_needed=$(cat /tmp/e2e-needed.txt)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Compile changed Python files
+        if: steps.scope.outputs.compile_files != ''
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          python -m py_compile $(cat /tmp/compile-files.txt)
+
+      - name: Run import and CLI smoke tests
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          python - <<'PY'
+          import importlib
+          for module in ('run_agent', 'model_tools', 'toolsets', 'hermes_cli.main'):
+              importlib.import_module(module)
+              print(f'import ok: {module}')
+          PY
+          hermes --version
+          hermes tools list >/tmp/hermes-tools.txt
+          test -s /tmp/hermes-tools.txt
+
+      - name: Run matching pytest targets
+        if: steps.scope.outputs.pytest_targets != ''
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          python -m pytest $(cat /tmp/pytest-targets.txt) -q --tb=short -n auto
+        env:
+          # Ensure tests don't accidentally call real APIs.
+          OPENROUTER_API_KEY: ""
+          OPENAI_API_KEY: ""
+          NOUS_API_KEY: ""
+
+      - name: Explain skipped broad suite
+        if: steps.scope.outputs.pytest_targets == ''
+        run: |
+          cat <<'EOF' >> "$GITHUB_STEP_SUMMARY"
+          ## Diff-scoped test selection
+
+          No direct pytest target matched the changed files. This workflow still
+          ran changed-file Python compilation plus import/CLI smoke tests.
+
+          The full upstream pytest suite is intentionally not a PR blocker on
+          Tangbao version branches while the upstream baseline is red; run it
+          manually/nightly for baseline debt tracking.
+          EOF
+
+  full-baseline:
+    name: full baseline tests
+    if: github.event_name == 'schedule' || github.event.inputs.run_full_suite == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
@@ -47,36 +233,61 @@ jobs:
           source .venv/bin/activate
           uv pip install -e ".[all,dev]"
 
-      - name: Run tests
+      - name: Run full baseline pytest
         run: |
           source .venv/bin/activate
           python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto
         env:
-          # Ensure tests don't accidentally call real APIs
           OPENROUTER_API_KEY: ""
           OPENAI_API_KEY: ""
           NOUS_API_KEY: ""
 
   e2e:
+    name: e2e when touched
+    if: github.event_name != 'schedule' && github.event.inputs.run_full_suite != 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect e2e changes
+        id: scope
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            git fetch origin "${{ github.base_ref }}" --depth=1 || true
+            BASE="$(git merge-base "origin/${{ github.base_ref }}" HEAD)"
+          else
+            BASE="$(git rev-parse HEAD~1 2>/dev/null || git rev-parse HEAD)"
+          fi
+          if git diff --name-only --diff-filter=ACMR "$BASE"..HEAD | grep -q '^tests/e2e/'; then
+            echo "run_e2e=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_e2e=false" >> "$GITHUB_OUTPUT"
+            echo "No tests/e2e changes; skipping e2e suite."
+          fi
 
       - name: Install uv
+        if: steps.scope.outputs.run_e2e == 'true'
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 
       - name: Set up Python 3.11
+        if: steps.scope.outputs.run_e2e == 'true'
         run: uv python install 3.11
 
       - name: Install dependencies
+        if: steps.scope.outputs.run_e2e == 'true'
         run: |
           uv venv .venv --python 3.11
           source .venv/bin/activate
           uv pip install -e ".[all,dev]"
 
       - name: Run e2e tests
+        if: steps.scope.outputs.run_e2e == 'true'
         run: |
           source .venv/bin/activate
           python -m pytest tests/e2e/ -v --tb=short


### PR DESCRIPTION
## Summary
- Replaces the PR-blocking full pytest job with diff-scoped test selection for `master` / `master-v*` PRs.
- Always keeps changed-file `py_compile`, core import smoke, `hermes --version`, and `hermes tools list` as fast guards.
- Runs directly matching pytest files only, e.g. `gateway/platforms/feishu.py` maps to `tests/gateway/test_feishu.py`.
- Runs e2e only when `tests/e2e/**` changes.
- Keeps full non-integration pytest available via manual `workflow_dispatch` (`run_full_suite=true`) and daily scheduled baseline tracking, so upstream baseline debt is visible but does not block unrelated small PRs.

## Why
Official upstream `main` currently has red full-suite baseline runs. Treating full `pytest tests/` as a required PR gate on Tangbao version branches blocks unrelated fixes such as Feishu-only changes. This makes PR CI difference-first while preserving baseline visibility.

## Validation
- YAML parsed successfully with Python `yaml.safe_load`.
- `git diff --check` passed.
- Simulated #19-style changed files (`gateway/platforms/feishu.py`, `tests/gateway/test_feishu.py`) select only:
  - `tests/gateway/test_feishu.py`
  - compile target: `gateway/platforms/feishu.py`
