### PR TITLE
fix(codex): don't pass tools=None in Responses API kwargs

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -100,10 +100,10 @@ class ResponsesApiTransport(ProviderTransport):
                 payload_messages,
                 is_xai_responses=is_xai_responses,
             ),
-            "tools": response_tools,
             "store": False,
         }
         if response_tools:
+            kwargs["tools"] = response_tools
             kwargs["tool_choice"] = "auto"
             kwargs["parallel_tool_calls"] = True
 


### PR DESCRIPTION
## Summary

Fix Codex transport crash: `'NoneType' object is not iterable`

## Root Cause

When `_responses_tools(tools)` returns a falsy value (None, empty list), the transport was still inserting `"tools": None` into the kwargs dict. The Codex backend (`/backend-api/codex`) responds with `"output": null` in its SSE `response.completed` event when it receives `tools=null`, causing the OpenAI SDK to raise `TypeError` on iteration over None.

## Fix

Only set `kwargs["tools"]` when `response_tools` is truthy.

## Files Changed

- `agent/transports/codex.py`: 1 line changed

## Testing

```bash
pytest tests/agent/transports/test_codex_transport.py -v    # 39 passed
pytest tests/run_agent/test_run_agent_codex_responses.py -v  # 47 passed
pytest tests/agent/transports/test_transport.py -v           # all passed
```

## Verification

```python
transport = ResponsesApiTransport()
result = transport.build_kwargs('gpt-4o', [{'role':'user','content':'hi'}], tools=None)
assert 'tools' not in result  # tools=None no longer leaks into kwargs
```