### PR TITLE
fix: recover from null-output TypeError in Codex Responses streams

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -788,28 +788,29 @@ class _CodexCompletionsAdapter:
                 timeout_timer.start()
             _check_cancelled()
             with self._client.responses.stream(**resp_kwargs) as stream:
-                for _event in stream:
-                    _check_cancelled()
-                    _etype = getattr(_event, "type", "")
-                    if _etype == "response.output_item.done":
-                        _done = getattr(_event, "item", None)
-                        if _done is not None:
-                            collected_output_items.append(_done)
-                    elif "output_text.delta" in _etype:
-                        _delta = getattr(_event, "delta", "")
-                        if _delta:
-                            collected_text_deltas.append(_delta)
-                    elif "function_call" in _etype:
-                        has_function_calls = True
-                _check_cancelled()
                 final = None
                 try:
+                    for _event in stream:
+                        _check_cancelled()
+                        _etype = getattr(_event, "type", "")
+                        if _etype == "response.output_item.done":
+                            _done = getattr(_event, "item", None)
+                            if _done is not None:
+                                collected_output_items.append(_done)
+                        elif "output_text.delta" in _etype:
+                            _delta = getattr(_event, "delta", "")
+                            if _delta:
+                                collected_text_deltas.append(_delta)
+                        elif "function_call" in _etype:
+                            has_function_calls = True
+                    _check_cancelled()
                     final = stream.get_final_response()
                 except TypeError as exc:
                     if not _is_codex_null_output_type_error(exc):
                         raise
-                    # Recovery: SDK cannot iterate null output, but we
-                    # have stream events. Synthesize a valid response.
+                    # Recovery: SDK cannot iterate null output (can happen
+                    # during for-event iteration OR get_final_response).
+                    # Synthesize a valid response from collected stream data.
                     if collected_output_items:
                         final = SimpleNamespace(
                             output=list(collected_output_items),

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -626,6 +626,13 @@ def _convert_content_for_responses(content: Any) -> Any:
     return converted or ""
 
 
+def _is_codex_null_output_type_error(exc: BaseException) -> bool:
+    """Return True when the exception is the specific TypeError produced by
+    the OpenAI SDK when a Codex backend returns response.completed with
+    ``response.output == null``, which then fails internal iteration."""
+    return isinstance(exc, TypeError) and "'NoneType' object is not iterable" in str(exc)
+
+
 class _CodexCompletionsAdapter:
     """Drop-in shim that accepts chat.completions.create() kwargs and
     routes them through the Codex Responses streaming API."""
@@ -795,18 +802,53 @@ class _CodexCompletionsAdapter:
                     elif "function_call" in _etype:
                         has_function_calls = True
                 _check_cancelled()
-                final = stream.get_final_response()
+                final = None
+                try:
+                    final = stream.get_final_response()
+                except TypeError as exc:
+                    if not _is_codex_null_output_type_error(exc):
+                        raise
+                    # Recovery: SDK cannot iterate null output, but we
+                    # have stream events. Synthesize a valid response.
+                    if collected_output_items:
+                        final = SimpleNamespace(
+                            output=list(collected_output_items),
+                            status="completed",
+                            model=model,
+                            usage=None,
+                        )
+                        logger.debug(
+                            "Codex auxiliary: recovered %d output items after null-output TypeError",
+                            len(collected_output_items),
+                        )
+                    elif collected_text_deltas and not has_function_calls:
+                        assembled = "".join(collected_text_deltas)
+                        final = SimpleNamespace(
+                            output=[SimpleNamespace(
+                                type="message", role="assistant", status="completed",
+                                content=[SimpleNamespace(type="output_text", text=assembled)],
+                            )],
+                            status="completed",
+                            model=model,
+                            usage=None,
+                        )
+                        logger.debug(
+                            "Codex auxiliary: recovered text from %d deltas (%d chars) after null-output TypeError",
+                            len(collected_text_deltas), len(assembled),
+                        )
+                    else:
+                        raise  # Nothing to recover
 
-            # Backfill empty output from collected stream events
+            # Backfill empty/null output from collected stream events
             _output = getattr(final, "output", None)
-            if isinstance(_output, list) and not _output:
-                if collected_output_items:
+            if not isinstance(_output, list) or not _output:
+                if collected_output_items and not _output:
                     final.output = list(collected_output_items)
                     logger.debug(
                         "Codex auxiliary: backfilled %d output items from stream events",
                         len(collected_output_items),
                     )
-                elif collected_text_deltas and not has_function_calls:
+                elif collected_text_deltas and not has_function_calls and not _output:
                     # Only synthesize text when no tool calls were streamed —
                     # a function_call response with incidental text should not
                     # be collapsed into a plain-text message.

--- a/run_agent.py
+++ b/run_agent.py
@@ -7334,22 +7334,36 @@ class AIAgent:
                 if terminal_response is None and isinstance(event, dict):
                     terminal_response = event.get("response")
                 if terminal_response is not None:
+                    # Helpers that read/write a field on either a namespace
+                    # object (getattr/setattr) or a raw dict ([] / .get).
+                    def _resp_get(obj, key, default=None):
+                        val = getattr(obj, key, None)
+                        if val is None and isinstance(obj, dict):
+                            val = obj.get(key, default)
+                        return val if val is not None else default
+
+                    def _resp_set(obj, key, value):
+                        if isinstance(obj, dict):
+                            obj[key] = value
+                        else:
+                            setattr(obj, key, value)
+
                     # Backfill empty/null output from collected stream events
-                    _out = getattr(terminal_response, "output", None)
+                    _out = _resp_get(terminal_response, "output", None)
                     if not isinstance(_out, list) or not _out:
                         if collected_output_items:
-                            terminal_response.output = list(collected_output_items)
+                            _resp_set(terminal_response, "output", list(collected_output_items))
                             logger.debug(
                                 "Codex fallback stream: backfilled %d output items",
                                 len(collected_output_items),
                             )
                         elif collected_text_deltas:
                             assembled = "".join(collected_text_deltas)
-                            terminal_response.output = [SimpleNamespace(
+                            _resp_set(terminal_response, "output", [SimpleNamespace(
                                 type="message", role="assistant",
                                 status="completed",
                                 content=[SimpleNamespace(type="output_text", text=assembled)],
-                            )]
+                            )])
                             logger.debug(
                                 "Codex fallback stream: synthesized from %d deltas (%d chars)",
                                 len(collected_text_deltas), len(assembled),

--- a/run_agent.py
+++ b/run_agent.py
@@ -7090,6 +7090,13 @@ class AIAgent:
     def _close_request_openai_client(self, client: Any, *, reason: str) -> None:
         self._close_openai_client(client, reason=reason, shared=False)
 
+    @staticmethod
+    def _is_codex_null_output_type_error(exc: BaseException) -> bool:
+        """Return True when the exception is the specific TypeError produced by
+        the OpenAI SDK when a Codex backend returns response.completed with
+        ``response.output == null``, which then fails internal iteration."""
+        return isinstance(exc, TypeError) and "'NoneType' object is not iterable" in str(exc)
+
     def _run_codex_stream(self, api_kwargs: dict, client: Any = None, on_first_delta: callable = None):
         """Execute one streaming Responses API request and return the final response."""
         import httpx as _httpx
@@ -7155,19 +7162,55 @@ class AIAgent:
                                 sum(len(p) for p in self._codex_streamed_text_parts),
                                 self._client_log_context(),
                             )
-                    final_response = stream.get_final_response()
-                    # PATCH: ChatGPT Codex backend streams valid output items
-                    # but get_final_response() can return an empty output list.
-                    # Backfill from collected items or synthesize from deltas.
-                    _out = getattr(final_response, "output", None)
-                    if isinstance(_out, list) and not _out:
+                    final_response = None
+                    try:
+                        final_response = stream.get_final_response()
+                    except TypeError as exc:
+                        if not self._is_codex_null_output_type_error(exc):
+                            raise
+                        # Recovery: SDK cannot iterate null output, but we
+                        # have stream events. Synthesize a valid response.
                         if collected_output_items:
+                            final_response = SimpleNamespace(
+                                output=list(collected_output_items),
+                                status="completed",
+                                model=api_kwargs.get("model", ""),
+                                usage=None,
+                            )
+                            logger.debug(
+                                "Codex stream: recovered %d output items after null-output TypeError",
+                                len(collected_output_items),
+                            )
+                        elif self._codex_streamed_text_parts and not has_tool_calls:
+                            assembled = "".join(self._codex_streamed_text_parts)
+                            final_response = SimpleNamespace(
+                                output=[SimpleNamespace(
+                                    type="message", role="assistant", status="completed",
+                                    content=[SimpleNamespace(type="output_text", text=assembled)],
+                                )],
+                                status="completed",
+                                model=api_kwargs.get("model", ""),
+                                usage=None,
+                            )
+                            logger.debug(
+                                "Codex stream: recovered text from %d deltas (%d chars) after null-output TypeError",
+                                len(self._codex_streamed_text_parts), len(assembled),
+                            )
+                        else:
+                            raise  # Nothing to recover
+                    # PATCH: ChatGPT Codex backend streams valid output items
+                    # but get_final_response() can return an empty output list
+                    # or None. Backfill from collected items or synthesize
+                    # from deltas.
+                    _out = getattr(final_response, "output", None)
+                    if not isinstance(_out, list) or not _out:
+                        if collected_output_items and not _out:
                             final_response.output = list(collected_output_items)
                             logger.debug(
                                 "Codex stream: backfilled %d output items from stream events",
                                 len(collected_output_items),
                             )
-                        elif self._codex_streamed_text_parts and not has_tool_calls:
+                        elif self._codex_streamed_text_parts and not has_tool_calls and not _out:
                             assembled = "".join(self._codex_streamed_text_parts)
                             final_response.output = [SimpleNamespace(
                                 type="message",

--- a/run_agent.py
+++ b/run_agent.py
@@ -7115,61 +7115,62 @@ class AIAgent:
             collected_output_items: list = []
             try:
                 with active_client.responses.stream(**api_kwargs) as stream:
-                    for event in stream:
-                        self._touch_activity("receiving stream response")
-                        if self._interrupt_requested:
-                            break
-                        event_type = getattr(event, "type", "")
-                        # Fire callbacks on text content deltas (suppress during tool calls)
-                        if "output_text.delta" in event_type or event_type == "response.output_text.delta":
-                            delta_text = getattr(event, "delta", "")
-                            if delta_text:
-                                self._codex_streamed_text_parts.append(delta_text)
-                            if delta_text and not has_tool_calls:
-                                if not first_delta_fired:
-                                    first_delta_fired = True
-                                    if on_first_delta:
-                                        try:
-                                            on_first_delta()
-                                        except Exception:
-                                            pass
-                                self._fire_stream_delta(delta_text)
-                        # Track tool calls to suppress text streaming
-                        elif "function_call" in event_type:
-                            has_tool_calls = True
-                        # Fire reasoning callbacks
-                        elif "reasoning" in event_type and "delta" in event_type:
-                            reasoning_text = getattr(event, "delta", "")
-                            if reasoning_text:
-                                self._fire_reasoning_delta(reasoning_text)
-                        # Collect completed output items — some backends
-                        # (chatgpt.com/backend-api/codex) stream valid items
-                        # via response.output_item.done but the SDK's
-                        # get_final_response() returns an empty output list.
-                        elif event_type == "response.output_item.done":
-                            done_item = getattr(event, "item", None)
-                            if done_item is not None:
-                                collected_output_items.append(done_item)
-                        # Log non-completed terminal events for diagnostics
-                        elif event_type in {"response.incomplete", "response.failed"}:
-                            resp_obj = getattr(event, "response", None)
-                            status = getattr(resp_obj, "status", None) if resp_obj else None
-                            incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
-                            logger.warning(
-                                "Codex Responses stream received terminal event %s "
-                                "(status=%s, incomplete_details=%s, streamed_chars=%d). %s",
-                                event_type, status, incomplete_details,
-                                sum(len(p) for p in self._codex_streamed_text_parts),
-                                self._client_log_context(),
-                            )
                     final_response = None
                     try:
+                        for event in stream:
+                            self._touch_activity("receiving stream response")
+                            if self._interrupt_requested:
+                                break
+                            event_type = getattr(event, "type", "")
+                            # Fire callbacks on text content deltas (suppress during tool calls)
+                            if "output_text.delta" in event_type or event_type == "response.output_text.delta":
+                                delta_text = getattr(event, "delta", "")
+                                if delta_text:
+                                    self._codex_streamed_text_parts.append(delta_text)
+                                if delta_text and not has_tool_calls:
+                                    if not first_delta_fired:
+                                        first_delta_fired = True
+                                        if on_first_delta:
+                                            try:
+                                                on_first_delta()
+                                            except Exception:
+                                                pass
+                                    self._fire_stream_delta(delta_text)
+                            # Track tool calls to suppress text streaming
+                            elif "function_call" in event_type:
+                                has_tool_calls = True
+                            # Fire reasoning callbacks
+                            elif "reasoning" in event_type and "delta" in event_type:
+                                reasoning_text = getattr(event, "delta", "")
+                                if reasoning_text:
+                                    self._fire_reasoning_delta(reasoning_text)
+                            # Collect completed output items — some backends
+                            # (chatgpt.com/backend-api/codex) stream valid items
+                            # via response.output_item.done but the SDK's
+                            # get_final_response() returns an empty output list.
+                            elif event_type == "response.output_item.done":
+                                done_item = getattr(event, "item", None)
+                                if done_item is not None:
+                                    collected_output_items.append(done_item)
+                            # Log non-completed terminal events for diagnostics
+                            elif event_type in {"response.incomplete", "response.failed"}:
+                                resp_obj = getattr(event, "response", None)
+                                status = getattr(resp_obj, "status", None) if resp_obj else None
+                                incomplete_details = getattr(resp_obj, "incomplete_details", None) if resp_obj else None
+                                logger.warning(
+                                    "Codex Responses stream received terminal event %s "
+                                    "(status=%s, incomplete_details=%s, streamed_chars=%d). %s",
+                                    event_type, status, incomplete_details,
+                                    sum(len(p) for p in self._codex_streamed_text_parts),
+                                    self._client_log_context(),
+                                )
                         final_response = stream.get_final_response()
                     except TypeError as exc:
                         if not self._is_codex_null_output_type_error(exc):
                             raise
-                        # Recovery: SDK cannot iterate null output, but we
-                        # have stream events. Synthesize a valid response.
+                        # Recovery: SDK cannot iterate null output (can happen
+                        # during for-event iteration OR get_final_response).
+                        # Synthesize a valid response from collected stream data.
                         if collected_output_items:
                             final_response = SimpleNamespace(
                                 output=list(collected_output_items),
@@ -7333,9 +7334,9 @@ class AIAgent:
                 if terminal_response is None and isinstance(event, dict):
                     terminal_response = event.get("response")
                 if terminal_response is not None:
-                    # Backfill empty output from collected stream events
+                    # Backfill empty/null output from collected stream events
                     _out = getattr(terminal_response, "output", None)
-                    if isinstance(_out, list) and not _out:
+                    if not isinstance(_out, list) or not _out:
                         if collected_output_items:
                             terminal_response.output = list(collected_output_items)
                             logger.debug(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2808,3 +2808,41 @@ class TestAuxUnhealthyCache:
             )
             # After the 402, OpenRouter is in the unhealthy cache.
             assert _is_provider_unhealthy("openrouter") is True
+
+
+def test_codex_adapter_recovers_text_after_null_output_typeerror(monkeypatch):
+    """_CodexCompletionsAdapter.create(): stream yields output_text.delta,
+    get_final_response() raises TypeError because response.output is null.
+    Should recover and return a valid chat.completions-like object."""
+    from agent.auxiliary_client import _is_codex_null_output_type_error
+
+    collected_deltas = []
+
+    class _FakeStream:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def __iter__(self):
+            return iter([
+                SimpleNamespace(type="response.output_text.delta", delta="Hello "),
+                SimpleNamespace(type="response.output_text.delta", delta="aux"),
+            ])
+
+        def get_final_response(self):
+            raise TypeError("'NoneType' object is not iterable")
+
+    fake_client = MagicMock()
+    fake_client.responses.stream.side_effect = lambda **kw: _FakeStream()
+
+    adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
+    result = adapter.create(
+        messages=[{"role": "user", "content": "hi"}],
+    )
+
+    assert result.choices[0].message.content == "Hello aux"
+    assert result.choices[0].message.role == "assistant"
+    assert result.model == "gpt-5.5"
+    assert result.choices[0].finish_reason == "stop"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2812,13 +2812,15 @@ class TestAuxUnhealthyCache:
 
 def test_codex_adapter_recovers_text_after_null_output_typeerror(monkeypatch):
     """_CodexCompletionsAdapter.create(): stream yields output_text.delta,
-    get_final_response() raises TypeError because response.output is null.
-    Should recover and return a valid chat.completions-like object."""
+    then raises TypeError during iteration (SDK handle_event crashes on
+    null response.output). Should recover and return a valid
+    chat.completions-like object."""
     from agent.auxiliary_client import _is_codex_null_output_type_error
 
-    collected_deltas = []
-
     class _FakeStream:
+        def __init__(self):
+            self._iter_done = False
+
         def __enter__(self):
             return self
 
@@ -2826,13 +2828,12 @@ def test_codex_adapter_recovers_text_after_null_output_typeerror(monkeypatch):
             return False
 
         def __iter__(self):
-            return iter([
-                SimpleNamespace(type="response.output_text.delta", delta="Hello "),
-                SimpleNamespace(type="response.output_text.delta", delta="aux"),
-            ])
+            yield SimpleNamespace(type="response.output_text.delta", delta="Hello ")
+            yield SimpleNamespace(type="response.output_text.delta", delta="aux")
+            raise TypeError("'NoneType' object is not iterable")
 
         def get_final_response(self):
-            raise TypeError("'NoneType' object is not iterable")
+            return None  # never reached
 
     fake_client = MagicMock()
     fake_client.responses.stream.side_effect = lambda **kw: _FakeStream()

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -2089,3 +2089,50 @@ def test_run_codex_stream_recovers_from_typeerror_in_get_final_response(monkeypa
     assert len(response.output) == 1
     assert response.output[0].type == "function_call"
     assert response.output[0].name == "read_file"
+
+
+def test_run_codex_stream_fallback_recovers_terminal_null_output(monkeypatch):
+    """create(stream=True) fallback where terminal response.output is None
+    (not empty list). Backfill code uses the updated condition
+    `not isinstance(_out, list) or not _out` and the dict/namespace-aware
+    _resp_get/_resp_set helpers to read/write 'output'."""
+    agent = _build_agent(monkeypatch)
+    calls = {"stream": 0, "create": 0}
+
+    # Terminal response with output=None exercises the expanded condition
+    create_stream = _FakeCreateStream([
+        SimpleNamespace(type="response.created"),
+        SimpleNamespace(type="response.in_progress"),
+        SimpleNamespace(type="response.output_text.delta", delta="fallback "),
+        SimpleNamespace(type="response.output_text.delta", delta="text"),
+        SimpleNamespace(type="response.completed", response=SimpleNamespace(
+            output=None, model="gpt-5-codex",
+        )),
+    ])
+
+    def _fake_stream(**kwargs):
+        calls["stream"] += 1
+        return _FakeResponsesStream(
+            final_error=RuntimeError("Didn't receive a `response.completed` event.")
+        )
+
+    def _fake_create(**kwargs):
+        calls["create"] += 1
+        assert kwargs.get("stream") is True
+        return create_stream
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(
+            stream=_fake_stream,
+            create=_fake_create,
+        )
+    )
+
+    response = agent._run_codex_stream(_codex_request_kwargs())
+    assert calls["stream"] == 2
+    assert calls["create"] == 1
+    assert create_stream.closed is True
+    # output=None was backfilled from collected deltas
+    assert response.output[0].type == "message"
+    assert response.output[0].content[0].text == "fallback text"
+    assert response.model == "gpt-5-codex"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1970,12 +1970,19 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
 # ── Null-output TypeError recovery ──────────────────────────────────────────
 
 class _FakeResponsesStreamWithEvents:
-    """Variant of _FakeResponsesStream that also yields stream events."""
+    """Variant of _FakeResponsesStream that also yields stream events.
 
-    def __init__(self, events=(), *, final_response=None, final_error=None):
+    Supports two error injection points:
+      - iter_error: raises during __iter__ after yielding all events
+        (simulates SDK handle_event() crashing on response.completed)
+      - final_error: raises from get_final_response()
+    """
+
+    def __init__(self, events=(), *, final_response=None, final_error=None, iter_error=None):
         self._events = list(events)
         self._final_response = final_response
         self._final_error = final_error
+        self._iter_error = iter_error
 
     def __enter__(self):
         return self
@@ -1984,7 +1991,10 @@ class _FakeResponsesStreamWithEvents:
         return False
 
     def __iter__(self):
-        return iter(self._events)
+        for ev in self._events:
+            yield ev
+        if self._iter_error is not None:
+            raise self._iter_error
 
     def get_final_response(self):
         if self._final_error is not None:
@@ -1993,8 +2003,8 @@ class _FakeResponsesStreamWithEvents:
 
 
 def test_run_codex_stream_recovers_text_from_deltas_after_null_output_typeerror(monkeypatch):
-    """Stream yields text deltas; get_final_response() raises TypeError
-    because response.completed.output is null. Should recover and
+    """Stream yields text deltas; TypeError during iteration (SDK
+    handle_event fails on null response.output). Should recover and
     synthesize a valid response from collected deltas."""
     agent = _build_agent(monkeypatch)
     api_kwargs = _codex_request_kwargs()
@@ -2005,7 +2015,7 @@ def test_run_codex_stream_recovers_text_from_deltas_after_null_output_typeerror(
     ]
     fake_stream = _FakeResponsesStreamWithEvents(
         stream_events,
-        final_error=TypeError("'NoneType' object is not iterable"),
+        iter_error=TypeError("'NoneType' object is not iterable"),
     )
 
     agent.client = SimpleNamespace(
@@ -2019,8 +2029,8 @@ def test_run_codex_stream_recovers_text_from_deltas_after_null_output_typeerror(
 
 
 def test_run_codex_stream_recovers_tool_call_after_null_output_typeerror(monkeypatch):
-    """Stream yields function_call output_item.done; get_final_response()
-    raises TypeError. Should recover with the function_call item intact,
+    """Stream yields function_call output_item.done; TypeError during
+    iteration. Should recover with the function_call item intact,
     NOT synthesize a plain-text message."""
     agent = _build_agent(monkeypatch)
     api_kwargs = _codex_request_kwargs()
@@ -2037,7 +2047,7 @@ def test_run_codex_stream_recovers_tool_call_after_null_output_typeerror(monkeyp
     ]
     fake_stream = _FakeResponsesStreamWithEvents(
         stream_events,
-        final_error=TypeError("'NoneType' object is not iterable"),
+        iter_error=TypeError("'NoneType' object is not iterable"),
     )
 
     agent.client = SimpleNamespace(
@@ -2048,3 +2058,34 @@ def test_run_codex_stream_recovers_tool_call_after_null_output_typeerror(monkeyp
     assert len(response.output) == 1
     assert response.output[0].type == "function_call"
     assert response.output[0].name == "terminal"
+
+
+def test_run_codex_stream_recovers_from_typeerror_in_get_final_response(monkeypatch):
+    """TypeError from get_final_response() (after iteration completes
+    without crashing) also recovers. Covers both injection points."""
+    agent = _build_agent(monkeypatch)
+    api_kwargs = _codex_request_kwargs()
+
+    fc_item = SimpleNamespace(
+        type="function_call",
+        id="fc_2",
+        call_id="call_2",
+        name="read_file",
+        arguments='{"path":"/tmp/x"}',
+    )
+    stream_events = [
+        SimpleNamespace(type="response.output_item.done", item=fc_item),
+    ]
+    fake_stream = _FakeResponsesStreamWithEvents(
+        stream_events,
+        final_error=TypeError("'NoneType' object is not iterable"),
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=lambda **kw: fake_stream)
+    )
+
+    response = agent._run_codex_stream(api_kwargs)
+    assert len(response.output) == 1
+    assert response.output[0].type == "function_call"
+    assert response.output[0].name == "read_file"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1965,3 +1965,86 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
     # IDs must be stripped — with store=False the API 404s on id lookups.
     for it in reasoning_items:
         assert "id" not in it
+
+
+# ── Null-output TypeError recovery ──────────────────────────────────────────
+
+class _FakeResponsesStreamWithEvents:
+    """Variant of _FakeResponsesStream that also yields stream events."""
+
+    def __init__(self, events=(), *, final_response=None, final_error=None):
+        self._events = list(events)
+        self._final_response = final_response
+        self._final_error = final_error
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def __iter__(self):
+        return iter(self._events)
+
+    def get_final_response(self):
+        if self._final_error is not None:
+            raise self._final_error
+        return self._final_response
+
+
+def test_run_codex_stream_recovers_text_from_deltas_after_null_output_typeerror(monkeypatch):
+    """Stream yields text deltas; get_final_response() raises TypeError
+    because response.completed.output is null. Should recover and
+    synthesize a valid response from collected deltas."""
+    agent = _build_agent(monkeypatch)
+    api_kwargs = _codex_request_kwargs()
+
+    stream_events = [
+        SimpleNamespace(type="response.output_text.delta", delta="Hello "),
+        SimpleNamespace(type="response.output_text.delta", delta="world"),
+    ]
+    fake_stream = _FakeResponsesStreamWithEvents(
+        stream_events,
+        final_error=TypeError("'NoneType' object is not iterable"),
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=lambda **kw: fake_stream)
+    )
+
+    response = agent._run_codex_stream(api_kwargs)
+    assert response.output[0].content[0].text == "Hello world"
+    assert response.status == "completed"
+    assert response.model == "gpt-5-codex"
+
+
+def test_run_codex_stream_recovers_tool_call_after_null_output_typeerror(monkeypatch):
+    """Stream yields function_call output_item.done; get_final_response()
+    raises TypeError. Should recover with the function_call item intact,
+    NOT synthesize a plain-text message."""
+    agent = _build_agent(monkeypatch)
+    api_kwargs = _codex_request_kwargs()
+
+    fc_item = SimpleNamespace(
+        type="function_call",
+        id="fc_1",
+        call_id="call_1",
+        name="terminal",
+        arguments="{}",
+    )
+    stream_events = [
+        SimpleNamespace(type="response.output_item.done", item=fc_item),
+    ]
+    fake_stream = _FakeResponsesStreamWithEvents(
+        stream_events,
+        final_error=TypeError("'NoneType' object is not iterable"),
+    )
+
+    agent.client = SimpleNamespace(
+        responses=SimpleNamespace(stream=lambda **kw: fake_stream)
+    )
+
+    response = agent._run_codex_stream(api_kwargs)
+    assert len(response.output) == 1
+    assert response.output[0].type == "function_call"
+    assert response.output[0].name == "terminal"


### PR DESCRIPTION
## Problem

Codex 私有 backend 返回 `response.completed.response.output = null` 时，OpenAI SDK 内部迭代 null 值触发 `TypeError: 'NoneType' object is not iterable`，导致 Hermes 的 Codex Responses 流式调用失败。

**关键发现 (CR):** 该 TypeError 有两个触发点：
1. `for event in stream` 迭代期间 — SDK `__iter__` → `handle_event()` → `parse_response()` 遍历 `response.output`
2. `stream.get_final_response()` 阶段

本机 prod SDK 的更可能触发点是迭代期（#1），因为 `response.completed` 事件在 `for event` 循环内就被 SDK 内部处理。

## Fix

### 1. 主 agent 路径 (`run_agent.py`)
- 新增 `_is_codex_null_output_type_error()` 静态方法
- `try/except TypeError` **包裹整个 `for event in stream` + `get_final_response()`**，确保迭代期和 get_final_response 期都能恢复
- 恢复逻辑：优先用 `collected_output_items`（保留 function_call），否则用 `streamed_text_parts` 合成 text message
- 回填条件从 `output==[]` 扩展为 `output 不是非空 list`（覆盖 `None`）
- Fallback 路径 (`_run_codex_create_stream_fallback`) 同样扩展回填条件

### 2. auxiliary 路径 (`agent/auxiliary_client.py`)
- 同样添加 `_is_codex_null_output_type_error()` 辅助函数
- `try/except TypeError` 同样包裹迭代 + get_final_response
- 同样扩展回填条件

### 3. 测试 (4 个)
| 测试 | 错误注入点 | 覆盖场景 |
|:---|:---|:---|
| text delta 恢复 | **迭代期** | text delta → 合成 |
| function_call 恢复 | **迭代期** | function_call → 保留 |
| get_final_response 恢复 | get_final_response | function_call → 保留 |
| auxiliary adapter 恢复 | **迭代期** | auxiliary adapter |

## 不改
- OAuth token 逻辑
- credential pool
- openai SDK vendor code
- systemd/service 配置

## 测试结果

```
tests/run_agent/test_run_agent_codex_responses.py: 54 passed
tests/agent/test_auxiliary_client.py:               172 passed
tests/run_agent/test_streaming.py:                  47 passed
tests/hermes_cli/test_auth_codex_provider.py:        12 passed
```

总计 **285 tests passed, 0 failures**

## CR 反馈处理

### High: TypeError can happen during iteration
→ **已修复**: try/except TypeError 从仅包 `get_final_response()` 扩展到包 `for event in stream` + `get_final_response()`
→ 测试新增 `iter_error` 注入点验证迭代期崩溃恢复

### Medium: fallback 路径只处理 output==[]
→ **已修复**: `_run_codex_create_stream_fallback` 的 backfill 条件改为 `not isinstance(_out, list) or not _out`