### PR TITLE
fix(feishu): restore reply markdown rendering for v2026.5.28

### DIFF
--- a/RELEASE_v2026.5.28-tangbao.1.md
+++ b/RELEASE_v2026.5.28-tangbao.1.md
@@ -1,0 +1,66 @@
+# Hermes Agent v2026.5.28-tangbao.1
+
+Tangbao custom release based on official Hermes Agent `v2026.5.28` / `v0.15.0`.
+
+- **Release date:** 2026-05-29
+- **Base version:** official `v2026.5.28` (`0c859a1c0`)
+- **Planned Git tag:** `v2026.5.28-tangbao.1`
+- **Release line:** 糖包定制版
+
+## Summary
+
+This release rebases Tangbao onto the official 2026.5.28 upstream release and reapplies the Feishu/Lark reply Markdown rendering fix that is not present in official `v2026.5.28`.
+
+## Changes since official `v2026.5.28`
+
+| Commit | Area | Description |
+| --- | --- | --- |
+| `f0baa2ba1` | Feishu gateway | Render Markdown replies/thread replies with native Feishu post elements instead of raw `tag: md` blocks. |
+
+## Feishu rendering fix
+
+Official `v2026.5.28` still sends Markdown content through Feishu post `md` elements. In reply or thread-reply surfaces, Feishu/Lark can render those `md` elements literally, causing headings, bold text, inline code, separators, and fenced code blocks to appear as raw Markdown.
+
+Tangbao `v2026.5.28-tangbao.1` keeps normal non-reply Markdown sends on the existing path, but switches reply/thread reply sends to native Feishu post elements:
+
+- headings / bold text -> `text` elements with `bold` style
+- inline code -> `text` elements with `code` style
+- fenced code blocks -> `code_block` elements
+- horizontal rules -> `hr` elements
+- links -> `a` elements
+
+## Validation
+
+Local validation on the upgrade branch:
+
+```text
+PYTHONPATH=$PWD /home/openclaw/hermes-prod/current/venv/bin/python -m pytest \
+  tests/gateway/test_feishu.py::TestAdapterBehavior::test_send_reply_uses_native_post_elements_for_markdown \
+  tests/gateway/test_feishu.py::TestAdapterBehavior::test_send_uses_post_for_inline_markdown \
+  tests/gateway/test_feishu.py::TestAdapterBehavior::test_send_splits_fenced_code_blocks_into_separate_post_rows \
+  tests/gateway/test_feishu.py::TestAdapterBehavior::test_send_falls_back_to_text_when_post_payload_is_rejected \
+  -q -o 'addopts='
+# 4 passed, 2 warnings
+
+PYTHONPATH=$PWD /home/openclaw/hermes-prod/current/venv/bin/python -m py_compile \
+  gateway/platforms/feishu.py tests/gateway/test_feishu.py
+# passed
+```
+
+Full Feishu gateway suite was also run locally for this release branch.
+
+## Contributors
+
+- Brownie — Tangbao patch replay and validation
+
+## Post-merge tagging
+
+After the release branch is merged into `master-v2026.5.28`, create the annotated tag from the merged release commit:
+
+```bash
+git fetch origin master-v2026.5.28 --tags
+git checkout master-v2026.5.28
+git pull --ff-only origin master-v2026.5.28
+git tag -a v2026.5.28-tangbao.1 -m "Hermes Agent v2026.5.28-tangbao.1"
+git push origin v2026.5.28-tangbao.1
+```

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -546,6 +546,136 @@ def _coerce_required_int(value: Any, default: int, min_value: int = 0) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _plain_text_element(text: str) -> Dict[str, Any]:
+    return {"tag": "text", "text": text}
+
+
+def _styled_text_element(text: str, *styles: str) -> Dict[str, Any]:
+    element: Dict[str, Any] = {"tag": "text", "text": text}
+    if styles:
+        element["style"] = list(styles)
+    return element
+
+
+def _append_text_element(row: List[Dict[str, Any]], text: str, *styles: str) -> None:
+    if not text:
+        return
+    element = _styled_text_element(text, *styles) if styles else _plain_text_element(text)
+    if row and row[-1].get("tag") == "text" and row[-1].get("style") == element.get("style"):
+        row[-1]["text"] = str(row[-1].get("text", "")) + text
+    else:
+        row.append(element)
+
+
+def _parse_inline_markdown_to_post_elements(text: str) -> List[Dict[str, Any]]:
+    """Best-effort inline Markdown conversion for Feishu reply post rows.
+
+    Feishu's reply surface renders post ``md`` elements unreliably, so reply
+    sends use native post elements for common AI-output formatting instead.
+    This is intentionally small and conservative, not a full Markdown parser.
+    """
+    row: List[Dict[str, Any]] = []
+    index = 0
+    while index < len(text):
+        if text.startswith("**", index):
+            end = text.find("**", index + 2)
+            if end > index + 2:
+                _append_text_element(row, text[index + 2:end], "bold")
+                index = end + 2
+                continue
+        if text.startswith("`", index):
+            end = text.find("`", index + 1)
+            if end > index + 1:
+                _append_text_element(row, text[index + 1:end], "code")
+                index = end + 1
+                continue
+        if text.startswith("~~", index):
+            end = text.find("~~", index + 2)
+            if end > index + 2:
+                _append_text_element(row, text[index + 2:end], "strikethrough")
+                index = end + 2
+                continue
+        if text.startswith("<u>", index):
+            end = text.find("</u>", index + 3)
+            if end > index + 3:
+                _append_text_element(row, text[index + 3:end], "underline")
+                index = end + 4
+                continue
+        if text.startswith("[", index):
+            match = _MARKDOWN_LINK_RE.match(text, index)
+            if match:
+                row.append({"tag": "a", "text": match.group(1), "href": match.group(2).strip()})
+                index = match.end()
+                continue
+        if text.startswith("*", index) and not text.startswith("**", index):
+            end = text.find("*", index + 1)
+            if end > index + 1:
+                _append_text_element(row, text[index + 1:end], "italic")
+                index = end + 1
+                continue
+        next_indices = [
+            pos for token in ("**", "`", "~~", "<u>", "[", "*")
+            if (pos := text.find(token, index + 1)) != -1
+        ]
+        next_index = min(next_indices) if next_indices else len(text)
+        _append_text_element(row, text[index:next_index])
+        index = next_index
+    return row or [_plain_text_element("")]
+
+
+def _build_native_markdown_post_rows(content: str) -> List[List[Dict[str, Any]]]:
+    rows: List[List[Dict[str, Any]]] = []
+    lines = content.replace("\r\n", "\n").splitlines()
+    index = 0
+    while index < len(lines):
+        line = lines[index]
+        stripped = line.strip()
+        fence_match = _MARKDOWN_FENCE_OPEN_RE.match(stripped)
+        if fence_match:
+            language = _sanitize_fence_language(fence_match.group(1))
+            code_lines: List[str] = []
+            index += 1
+            while index < len(lines) and not _MARKDOWN_FENCE_CLOSE_RE.match(lines[index].strip()):
+                code_lines.append(lines[index])
+                index += 1
+            if index < len(lines):
+                index += 1
+            rows.append([{"tag": "code_block", "language": language, "text": "\n".join(code_lines)}])
+            continue
+        if not stripped:
+            index += 1
+            continue
+        if re.fullmatch(r"---+", stripped):
+            rows.append([{"tag": "hr"}])
+            index += 1
+            continue
+        heading = re.match(r"^(#{1,6})\s+(.*)$", stripped)
+        if heading:
+            rows.append([_styled_text_element(heading.group(2), "bold")])
+            index += 1
+            continue
+        bullet = re.match(r"^\s*([-*])\s+(.*)$", line)
+        if bullet:
+            rows.append([_plain_text_element("• "), *_parse_inline_markdown_to_post_elements(bullet.group(2))])
+            index += 1
+            continue
+        numbered = re.match(r"^\s*(\d+)\.\s+(.*)$", line)
+        if numbered:
+            rows.append([_plain_text_element(f"{numbered.group(1)}. "), *_parse_inline_markdown_to_post_elements(numbered.group(2))])
+            index += 1
+            continue
+        rows.append(_parse_inline_markdown_to_post_elements(line))
+        index += 1
+    return rows or [[_plain_text_element("")]]
+
+
+def _build_native_markdown_post_payload(content: str) -> str:
+    return json.dumps(
+        {"zh_cn": {"content": _build_native_markdown_post_rows(content)}},
+        ensure_ascii=False,
+    )
+
+
 def _build_markdown_post_payload(content: str) -> str:
     rows = _build_markdown_post_rows(content)
     return json.dumps(
@@ -1778,7 +1908,11 @@ class FeishuAdapter(BasePlatformAdapter):
 
         try:
             for chunk in chunks:
-                msg_type, payload = self._build_outbound_payload(chunk)
+                native_markdown = bool(reply_to or (metadata or {}).get("thread_id"))
+                msg_type, payload = self._build_outbound_payload(
+                    chunk,
+                    native_markdown=native_markdown,
+                )
                 try:
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
@@ -4283,7 +4417,7 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
-    def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+    def _build_outbound_payload(self, content: str, *, native_markdown: bool = False) -> tuple[str, str]:
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.
@@ -4291,7 +4425,12 @@ class FeishuAdapter(BasePlatformAdapter):
             text_payload = {"text": content}
             return "text", json.dumps(text_payload, ensure_ascii=False)
         if _MARKDOWN_HINT_RE.search(content):
-            return "post", _build_markdown_post_payload(content)
+            payload = (
+                _build_native_markdown_post_payload(content)
+                if native_markdown
+                else _build_markdown_post_payload(content)
+            )
+            return "post", payload
         text_payload = {"text": content}
         return "text", json.dumps(text_payload, ensure_ascii=False)
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2578,6 +2578,63 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(elements, [{"tag": "md", "text": "可以用 **粗体** 和 *斜体*。"}])
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_reply_uses_native_post_elements_for_markdown(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_reply_markdown"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_chat",
+                    content="## 标题\n可以用 **粗体** 和 `代码`。\n---\n```python\nprint(1)\n```",
+                    reply_to="om_parent",
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["request"].request_body.msg_type, "post")
+        payload = json.loads(captured["request"].request_body.content)
+        rows = payload["zh_cn"]["content"]
+        self.assertNotIn('"tag": "md"', json.dumps(rows, ensure_ascii=False))
+        self.assertEqual(
+            rows,
+            [
+                [{"tag": "text", "text": "标题", "style": ["bold"]}],
+                [
+                    {"tag": "text", "text": "可以用 "},
+                    {"tag": "text", "text": "粗体", "style": ["bold"]},
+                    {"tag": "text", "text": " 和 "},
+                    {"tag": "text", "text": "代码", "style": ["code"]},
+                    {"tag": "text", "text": "。"},
+                ],
+                [{"tag": "hr"}],
+                [{"tag": "code_block", "language": "python", "text": "print(1)"}],
+            ],
+        )
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_splits_fenced_code_blocks_into_separate_post_rows(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## Summary
- Base Tangbao release work on official upstream `v2026.5.28` / `v0.15.0`.
- Reapply the Feishu/Lark reply Markdown rendering fix missing from official `v2026.5.28`.
- Add `RELEASE_v2026.5.28-tangbao.1.md` for the planned 糖包定制版 tag.

## Why
Official `v2026.5.28` still sends Markdown replies through Feishu `post` `tag: md` elements. Lark/Feishu reply and thread-reply surfaces can render those elements literally, causing headings, bold, inline code, separators, and fenced code blocks to appear as raw Markdown.

This patch keeps ordinary non-reply Markdown sends on the existing path and uses native Feishu post elements only for reply/thread reply sends.

## Test Plan
- `PYTHONPATH=$PWD /home/openclaw/hermes-prod/current/venv/bin/python -m pytest tests/gateway/test_feishu.py::TestAdapterBehavior::test_send_reply_uses_native_post_elements_for_markdown tests/gateway/test_feishu.py::TestAdapterBehavior::test_send_uses_post_for_inline_markdown tests/gateway/test_feishu.py::TestAdapterBehavior::test_send_splits_fenced_code_blocks_into_separate_post_rows tests/gateway/test_feishu.py::TestAdapterBehavior::test_send_falls_back_to_text_when_post_payload_is_rejected -q -o 'addopts='` → 4 passed
- `PYTHONPATH=$PWD /home/openclaw/hermes-prod/current/venv/bin/python -m py_compile gateway/platforms/feishu.py tests/gateway/test_feishu.py` → passed
- `PYTHONPATH=$PWD /home/openclaw/hermes-prod/current/venv/bin/python -m pytest tests/gateway/test_feishu.py -q -o 'addopts='` → 202 passed

## Release
Planned tag after merge: `v2026.5.28-tangbao.1`.

The leading date follows the upstream official base version date. This is the first Tangbao/custom release based on official `2026.5.28`, so the planned tag is `v2026.5.28-tangbao.1`.
